### PR TITLE
Fix typo 'betwen'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Valgomat algorithm
 
-> Calculate the distance betwen two sets of positions.
+> Calculate the distance between two sets of positions.
 
 Calculates the distance between two sets of positions. Mostly used to calculate the distance between various party positions and a voter position.
 


### PR DESCRIPTION
Jeg kommer hit fra NRKbeta-artikkelen, som forresten var ganske interessant. Jeg fant en typo i README.md. Det er kanskje litt mye å forke hele repoet bare for én bokstav, men nå er det gjort 😀

***

*I found a typo in README.md, here is a pull request just for ONE letter. I guess I could just submit an issue, but it's too late now..*