### PR TITLE
Fikset en skrivefeil i README for position sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Positions are given in the form of sets:
 
 ```ts
 {
-  [statement: string]: -2 | -1 | 1 | -2 | null
+  [statement: string]: -2 | -1 | 1 | 2 | null
 }
 ```
 


### PR DESCRIPTION
Verdien `-2` i position sets er lagt inn to ganger, endret den ene til rett verdi: `2`